### PR TITLE
Dynamically add next event to homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,5 +35,7 @@
           </div>
         </div>
 
+        <script src="//cdn.jsdelivr.net/g/jquery@2.1,momentjs@2.7"></script>
+        <script src="/application.js"></script>
     </body>
 </html>

--- a/application.js
+++ b/application.js
@@ -1,0 +1,18 @@
+(function($){
+  'use strict';
+
+  /* Fetch event data from Meetup and insert into page */
+
+  $.get('http://api.meetup.com/2/events?group_id=8008702&status=upcoming&order=time&limited_events=False&desc=false&offset=0&format=json&page=1&fields=&sig_id=8304535&sig=0ebddfa32cb4043b7bab3ee80fdee18145a34cbe&callback=?',
+    function(data){
+      var meetup = data.results[0]
+      meetup.date = moment(meetup.time)
+
+      $('#nextEvent').html(
+        '<h3 class="event-title"><a href="' + meetup.event_url + '">' + meetup.name + '</a></h3>' +
+        '<p>' + ' ' + meetup.date.format('dddd, MMMM D, YYYY') + '</p>' +
+        '<p>' + meetup.date.format('h:mma') + ' at ' + meetup.venue.name + '</p>'
+      )
+      $('#nextEventFromNow').text('Our next event is ' + meetup.date.fromNow() + ':')
+    }, 'jsonp')
+})(jQuery)

--- a/css/main.css
+++ b/css/main.css
@@ -94,6 +94,22 @@ ul.posts span {
 
   .header a.extra:hover { color: #000; }
 
+.event-tile {
+  border-left: .25em solid #a52a2a;
+  line-height: 1.2;
+  margin: 1em .75em;
+  padding: 0 1em;
+}
+  .event-tile .event-title {
+    color: #A52A2A;
+    font-weight: normal;
+    margin: 0;
+    padding-top: .125em;
+  }
+  .event-tile p {
+    margin: .25em 0;
+  }
+
 .footer {
   color: #666;
   border-top: .5em solid #eee;

--- a/index.md
+++ b/index.md
@@ -3,9 +3,11 @@ layout: default
 title: Asheville Coders League
 ---
 
-The Asheville Coders League is a group of coders who meet regularly on Wednesday nights at [Asheville Brewing and Pizza](http://www.ashevillebrewing.com/) on [Coxe Ave](http://www.openstreetmap.org/#map=19/35.59172/-82.55578).
+The Asheville Coders League is a group of coders who meet regularly on Wednesday nights. We also strive to have one technical meetup a month.
 
-We also strive to have one technical meetup a month, so please check our [Meetup page](http://www.meetup.com/Asheville-Coders-League/) to see where we will be on a given Wednesday.  
+<span id="nextEventFromNow">Find our next event on our <a href="http://www.meetup.com/Asheville-Coders-League/">Meetup page</a>.</span>
+
+<div class="event-tile" id="nextEvent"></div>
 
 Previous technical meetups include:
 


### PR DESCRIPTION
I thought it'd be cool if the homepage had something more specific/lively about our events, so I've added some code to fetch details about the next meetup and insert that into the homepage.

Meetup.com doesn't allow cross domain requests, so I had to create a [key-signed request](http://www.meetup.com/meetup_api/auth/#keysign) using my Meetup id.

Fallback content is provided and should make sense in cases where a user has JS disabled.

Screenshot:
![homepage-next-event](https://cloud.githubusercontent.com/assets/38445/3417744/c60b1062-fe3c-11e3-94c9-200766128b73.png)
