### PR TITLE
add slack link to chat page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
             <h1 class="title"><a href="/">{{ site.name }}</a></h1>
             <a class="extra" href="https://groups.google.com/forum/#!forum/asheville-coders">Google Groups</a>
             <a class="extra" href="http://www.meetup.com/Asheville-Coders-League/">Meetup.com</a>
-            <a class="extra" href="/chat.html">chat</a>
+            <a class="extra" href="/chat.html">Chat</a>
           </div>
         </div>
 

--- a/chat.md
+++ b/chat.md
@@ -7,7 +7,7 @@ title: Chat
 
 Slack is real-time messaging app available via a web interface as well as desktop and mobile applications.
 
-[Join AVL Coders League Slack Group](http://slack.avlcoders.org)
+[Join AVL Coders League Slack Group](https://slack-avlcoders.herokuapp.com)
 
 # IRC
 

--- a/chat.md
+++ b/chat.md
@@ -3,7 +3,13 @@ layout: default
 title: Chat
 ---
 
-# About IRC
+# Slack
+
+Slack is real-time messaging app available via a web interface as well as desktop and mobile applications.
+
+[Join AVL Coders League Slack Group](http://slack.avlcoders.org)
+
+# IRC
 
 Our chat system uses IRC, or "Internet Relay Chat". This is a time-tested method to connect and chat with each other online. You can either configure your own client, or use the links below to access IRC over the web. Stop in, say hello.
 


### PR DESCRIPTION
@tobias a bunch of us have been hanging out on a dedicated slack account for asheville coder's league. 

at the request of señor @wukkuan this commit adds a link to /chat.html page to join our slack group.

the join link goes to slack.avlcoders.org, so this first requires you to add a CNAME for slack.avlcoders.org pointing to slack-avlcoders.herokuapp.com.
