### PR TITLE
use rouge highlighter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gem 'github-pages'
-gem 'pygments.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,11 +104,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    posix-spawn (0.3.11)
     public_suffix (1.5.3)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -126,14 +122,12 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
-  pygments.rb
 
 BUNDLED WITH
    1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 name: Asheville Coders League
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge


### PR DESCRIPTION
> You are attempting to use the 'pygments' highlighter, which is currently unsupported
https://github.com/avlcoders/avlcoders.github.io/pull/13#issuecomment-209050540

ok, that makes sense now why `pygments.rb` was not included in bundle install anymore. this should fix things.