### PR TITLE
update Slack invitation link

### DIFF
--- a/chat.md
+++ b/chat.md
@@ -7,5 +7,5 @@ title: Chat
 
 Slack is real-time messaging app available via a web interface as well as desktop and mobile applications.
 
-[Join AVL Coders League Slack Group](http://slack.avlcoders.org)
+[Join AVL Coders League Slack Group](https://join.slack.com/t/avlcoders/shared_invite/zt-hkc081hw-X4NA_XePAQaEFG4dvjmRd://join.slack.com/t/avlcoders/shared_invite/zt-hkc081hw-X4NA_XePAQaEFG4dvjmRdA)
 


### PR DESCRIPTION
The Heroku app that was supporting community sign-ups to our Slack group no longer works, as Slack has deprecated the relevant APIs.

Users can now create invitation links directly in the UI, but they expire every 30 days, so this change is a bandage, at best.

I don't know who owns the domain and DNS info, but the `slack.avlcoders.org` subdomain can go away for now.